### PR TITLE
build: Fix path to /git/calamari-clients

### DIFF
--- a/vagrant/salt/roots/git_clone.sls
+++ b/vagrant/salt/roots/git_clone.sls
@@ -3,5 +3,5 @@ git_clone:
     - latest
     - user: vagrant
     - target: /home/vagrant/clients
-    - name: /git/clients
+    - name: /git/calamari-clients
 


### PR DESCRIPTION
This was hardcoded for the old repo name.  It's still
undesirable for the path here to be hardcoded at all,
but at least this will work with a default-named
checkout.

Signed-off-by: John Spray john.spray@redhat.com
