### PR TITLE
Fix Pools Total Disk Free graph to display bytes rather than kB

### DIFF
--- a/dashboard/app/scripts/templates/graphite/PoolDiskFreeTarget.ejs
+++ b/dashboard/app/scripts/templates/graphite/PoolDiskFreeTarget.ejs
@@ -1,1 +1,1 @@
-ceph.cluster.<%- clusterName %>.df.<%- metric %>
+scale(ceph.cluster.<%- clusterName %>.df.<%- metric %>, 1024)


### PR DESCRIPTION
Ceph returns disk amounts in kB (i.e. divided by 1024).  Scale back
up by adding the graphite function scale(..,1024) to the template.

Fixes: #8853
Signed-off-by: John Spray john.spray@inktank.com
Reviewed-by: Dan Mick dan.mick@inktank.com
