### PR TITLE
precise-build needs bower@1.3.8

### DIFF
--- a/vagrant/salt/roots/full_build_deps.sls
+++ b/vagrant/salt/roots/full_build_deps.sls
@@ -25,7 +25,7 @@ install_node:
 
 bower:
     cmd.run:
-        - name: npm install -g bower@1.2.8
+        - name: npm install -g bower@1.3.8
     require:
         - pkg: install_node
 


### PR DESCRIPTION
precise-build fails with bower@1.2.8
but succeeds with bower@1.3.8

This problem is described in more details in
https://github.com/ceph/calamari-clients/issues/45

Signed-off-by: Kevin Dalley kevin@kelphead.org
