### PR TITLE
Build also requires ruby1.9.1-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Homepage: http://www.inktank.com/
 Maintainer: Inktank <info@intank.com>
 Standards-Version: 3.9.2
-Build-Depends: ruby1.9.1, make, git
+Build-Depends: ruby1.9.1, ruby1.9.1-dev, make, git
 
 Package: calamari-clients
 Architecture: all

--- a/vagrant/salt/roots/full_build_deps.sls
+++ b/vagrant/salt/roots/full_build_deps.sls
@@ -2,6 +2,7 @@ full_build_deps:
   pkg.installed:
     - pkgs:
       - ruby1.9.1
+      - ruby1.9.1-dev
       - python-software-properties
       - g++
       - make


### PR DESCRIPTION
This should be in master.  Not sure why it isn't.

Missing ruby1.9.1-dev causes compass build to fail.

Frustratingly, the build has been failing but Jenkins has not
been noticing; 'gem install compass' fails with

/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)

without ruby1.9.1-dev installed.

Signed-off-by: Dan Mick dan.mick@inktank.com
