### PR TITLE
Remove google analytics code from login page

### DIFF
--- a/dashboard/app/index.html
+++ b/dashboard/app/index.html
@@ -62,14 +62,6 @@
   <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
   <![endif]-->
 
-  <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
-  <!--script>
-  var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
-  (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-  g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-  s.parentNode.insertBefore(g,s)}(document,'script'));
-  </script-->
-
   <!-- build:js scripts/main.js -->
   <script data-main="scripts/main" src="bower_components/requirejs/require.js"></script>
   <!-- endbuild -->

--- a/login/app/index.html
+++ b/login/app/index.html
@@ -63,14 +63,6 @@
         <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
         <![endif]-->
 
-        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
-        <script>
-            var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
-            (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-                g.src='//www.google-analytics.com/ga.js';
-                s.parentNode.insertBefore(g,s)}(document,'script'));
-        </script>
-
         <!-- build:js scripts/main.js -->
         <script data-main="scripts/main" src="bower_components/requirejs/require.js"></script>
         <!-- endbuild -->


### PR DESCRIPTION
Both the login and dashboard pages include google analytics code.  This
is commented out on the dashboard page so has no effect there, but is
live on the login page.  This means any time someone tries to log in to
Calamari, their browser will hit Google's server with a bogus Google
Analytics site ID.  This seems rather undesirable to me.

Signed-off-by: Tim Serong tserong@suse.com
