### PR TITLE
Poll every 500ms to activate login button

### DIFF
--- a/login/app/scripts/app.js
+++ b/login/app/scripts/app.js
@@ -5,15 +5,14 @@ define(['underscore', 'jquery', 'backbone', 'gitcommit', 'jquery.cookie'], funct
     var LoginBox = Backbone.View.extend({
         events: {
             'click input[type="submit"]': 'loginHandler',
-            'submit form': 'loginHandler',
-            'input input[name="username"],input[name="password"]': 'loginToggle'
+            'submit form': 'loginHandler'
         },
         ui: {},
         iconTemplate: _.template('<i class="<%- iconClazz %>" icon-large"></i>'),
         initialize: function() {
             _.bindAll(this, 'loginHandler', 'loginToggle', 'toJSON', 'disableSubmit', 'enableSubmit', 'showErrors', 'hideErrors');
             // Issue #8352 Workaround Browser Autofill not sending input event
-            setTimeout(function() {
+            setInterval(function() {
                 this.loginToggle();
             }.bind(this), 500);
         },


### PR DESCRIPTION
There's another variant of issue #8352, where the form is initially
blank, but the user later types in a username which causes Firefox to
autofill the password field at this point in time, rather than on
initial pageload.  This does not trigger an input event, so the submit
button is never enabled.  To workaround this, I've changed setTimeout to
setInterval, so the page continually polls every 500ms.  This also means
we can remove the input event handlers, because the poll will pick up
the changed fields quickly anyway.

Signed-off-by: Tim Serong <tserong@suse.com>