### PR TITLE
disable actions for readonly users

### DIFF
--- a/manage/app/scripts/controllers/osd-host.js
+++ b/manage/app/scripts/controllers/osd-host.js
@@ -406,6 +406,19 @@
                     $scope.up = true;
                     $rootScope.keyTimer = $timeout(refreshOSDModels, config.getPollTimeoutMs());
                 });
+
+                // Actions on OSDs need to be disabled for a readonly user
+                // This is done by using the 'Allow' header of the respective resource through out the application
+                // But here, the osd's are fetched as a list and not as individual osd resources
+                // So we are going to fetch one osd resource, and disable the actions on all the osds based
+                // on the 'Allow' header
+                // This workaroud should be replaced with a proper approach in future
+                if (r.ids.length > 0 ) {
+                    OSDService.getFull(r.ids[0]).then(function (osd) {
+                        var headers = osd.headers('Allow');
+                        $scope.isUpdateAllowed = headers && headers.indexOf('PATCH') > 0;
+                    });
+                }
             });
 
         };

--- a/manage/app/scripts/controllers/pool-modify.js
+++ b/manage/app/scripts/controllers/pool-modify.js
@@ -23,6 +23,9 @@
             ];
             $scope.id = $routeParams.id;
 
+            $scope.isUpdateAllowed = false;
+            $scope.isDeleteAllowed = false;
+
             // re-calculate the pgnum if the replication size changes
             // only in new pool
             // Refer PoolHelpers.addWatches()
@@ -130,12 +133,16 @@
                 }
             };
 
-            var promises = [PoolService.get($scope.id), CrushService.getList()];
+            var promises = [PoolService.getFull($scope.id), CrushService.getList()];
 
             // Set up page.
             $q.all(promises).then(function(results) {
                 /* jshint camelcase:false */
-                $scope.pool = results[0];
+                $scope.pool = results[0].data;
+                var headers = results[0].headers('Allow');
+                $scope.isUpdateAllowed = headers && headers.indexOf('PATCH') > 0;
+                $scope.isDeleteAllowed = headers && headers.indexOf('DELETE') > 0;
+
                 $scope.defaults = angular.copy($scope.pool);
                 this.crushrulesets = results[1];
 

--- a/manage/app/scripts/controllers/root.js
+++ b/manage/app/scripts/controllers/root.js
@@ -123,7 +123,7 @@
                 $scope.updateSettings = cluster.updateSettings;
             });
 
-            var promises = [KeyService.getList(), ToolService.config(), OSDConfigService.get()];
+            var promises = [KeyService.getList(), ToolService.config(), OSDConfigService.getFull()];
             // Bootstrap the view after we the above API calls complete.
             var start = Date.now();
             $q.all(promises).then(function(results) {
@@ -168,9 +168,11 @@
                     $scope.configs = configs;
                 });
                 // Initialize the Cluster Wide Settings Config Data.
-                responseHelpers.osdConfigsInit(results[2]).then(function(osdConfigs) {
+                responseHelpers.osdConfigsInit(results[2].data).then(function(osdConfigs) {
                     $scope.osdconfigs = osdConfigs;
                     $scope.osdconfigsdefaults = angular.copy(osdConfigs);
+                    var headers = results[2].headers('Allow');
+                    $scope.isUpdateAllowed = headers && headers.indexOf('PATCH') > 0;
                 });
             });
         };

--- a/manage/app/scripts/services/osd-config-svc.js
+++ b/manage/app/scripts/services/osd-config-svc.js
@@ -11,6 +11,11 @@ define(['lodash'], function(_) {
                     return config;
                 });
             },
+            getFull: function() {
+                return this.restangular.clusterFull().one('osd_config').get().then(function(config) {
+                    return config;
+                });
+            },
             patch: function(config) {
                 return this.restangular.clusterFull().one('osd_config').patch(config);
             }

--- a/manage/app/scripts/services/osd-svc.js
+++ b/manage/app/scripts/services/osd-svc.js
@@ -40,6 +40,16 @@ define(['lodash'], function(_) {
                     return osd;
                 });
             },
+            // **getFull**
+            // **@param** *id* - id as number of OSD.
+            // **@returns** promise with the specified OSD metadata and
+            // extra fields like headers, status code, etc.
+            getFull: function(id) {
+                id = _.isString(id) ? parseInt(id, 10) : id;
+                return this.restangular.clusterFull().one('osd', id).get().then(function(osd) {
+                    return osd;
+                });
+            },
             // **patch**
             // **@param** *id* - id of OSD you wish to patch.
             //             ID must be parseable by parseInt.

--- a/manage/app/scripts/services/pool-svc.js
+++ b/manage/app/scripts/services/pool-svc.js
@@ -19,12 +19,31 @@ define(['lodash'], function(_) {
                     return pools;
                 });
             },
+            // **getListFull**
+            // **@returns** a promise which has a reponse object comprises of 
+            // list of all the pools being managed by this Cluster
+            // and extra fields like headers, status code, etc.
+            getListFull: function() {
+                return this.restangular.clusterFull().all('pool').getList().then(function(pools) {
+                    return pools;
+                });
+            },
             // **get**
             // **@param** id - id of the pool you wish to retrieve
             // **@returns** a promise with the meta data associated with this pool.
             get: function(id) {
                 id = _.isString(id) ? parseInt(id, 10) : id;
                 return this.restangular.cluster().one('pool', id).get().then(function(pool) {
+                    return pool;
+                });
+            },
+            // **getFull**
+            // **@param** id - id of the pool you wish to retrieve
+            // **@returns** a promise with the meta data associated with this pool
+            // and extra fields like headers, status code, etc.
+            getFull: function(id) {
+                id = _.isString(id) ? parseInt(id, 10) : id;
+                return this.restangular.clusterFull().one('pool', id).get().then(function(pool) {
                     return pool;
                 });
             },

--- a/manage/app/scripts/services/user-svc.js
+++ b/manage/app/scripts/services/user-svc.js
@@ -17,7 +17,10 @@ define(['lodash'], function(_) {
                 });
             },
             me: function() {
-                return this.get('me');
+                return this.get('me').then(function(me) {
+                    me.isReadOnly = true;
+                    return me;
+                });
             },
             logout: function() {
                 return this.restv1.one('auth').one('logout').get();

--- a/manage/app/views/osd-host.html
+++ b/manage/app/views/osd-host.html
@@ -35,7 +35,7 @@
                                     ng-if="!osd.in" class="label label-danger">OUT</span>
                                 </td>
                                 <td>
-                                    <input tabindex={{$index+1}} style="width: 4em;" type='number' min="0" max="100" ng-disabled='osd.editing || osd.editDisabled'
+                                    <input tabindex={{$index+1}} style="width: 4em;" type='number' min="0" max="100" ng-disabled='!isUpdateAllowed || osd.editing || osd.editDisabled'
                                     required=true name="reweight" ng-model='osd.reweight' ng-change='changedFn(osd)'
                                     />&nbsp; <i ng-show="osd.editing" class='fa fa-spinner fa-spin fa-lg fa-fw'></i>
 
@@ -46,12 +46,11 @@
                                 <td>
                                     <button ng-disabled='osd.disabled' type='button' ng-click='displayFn(osd.id)'
                                     class='btn btn-md btn-info'> <i class='fa fa-info-circle fa-fw fa-lg'></i>
-
                                     </button>
-                                    <button ng-disabled='osd.repairDisabled || osd.disabled' ng-bind-html='osd.repairText'
+                                    <button ng-disabled='!isUpdateAllowed || osd.repairDisabled || osd.disabled' ng-bind-html='osd.repairText'
                                     type='button' data-html='true' class='btn btn-md btn-danger' data-template="views/dropdown.tpl.html"
                                     bs-dropdown='osd.repairDropdown'></button>
-                                    <button ng-bind-html='osd.configText' ng-disabled='osd.disabled' type='button'
+                                    <button ng-bind-html='osd.configText' ng-disabled='!isUpdateAllowed || osd.disabled' type='button'
                                     data-html='true' class='btn btn-md btn-warning' data-template="views/dropdown.tpl.html"
                                     bs-dropdown='osd.configDropdown'></button>
                                 </td>

--- a/manage/app/views/partial-osd-config.html
+++ b/manage/app/views/partial-osd-config.html
@@ -121,6 +121,6 @@
 <div class="col-lg-8 col-md-8 col-sm-8 col-xs-8">
     <div>
         <button ng-click="reset()" class="btn btn-warning">RESET</button>
-        <button style="min-width: 100px;" ng-click="updateSettings()" ng-bind-html="updateLabel" class="btn" ng-class="{'btn-primary': updatePrimary, 'btn-success': updateSuccess, 'disabled': osdmapForm.$pristine || !updatePrimary }"></button>
+        <button style="min-width: 100px;" ng-click="updateSettings()" ng-bind-html="updateLabel" class="btn" ng-class="{'btn-primary': updatePrimary, 'btn-success': updateSuccess, 'disabled': osdmapForm.$pristine || !updatePrimary }" ng-disabled="!isUpdateAllowed"></button>
     </div>
 </div>

--- a/manage/app/views/pool-modify.html
+++ b/manage/app/views/pool-modify.html
@@ -49,10 +49,10 @@
                     </button>
                     <button type="button" class="btn btn-md btn-warning" ng-click='reset()' data-placement="center"><i class="fa fa-lg fa-fw fa-rotate-left" bs-tooltip="ttReset"></i>
                     </button>
-                    <button type="button" ng-class="{ 'disabled': !poolForm.$dirty || poolForm.$invalid }"
+                    <button type="button" ng-disabled="!isUpdateAllowed" ng-class="{ 'disabled': !poolForm.$dirty || poolForm.$invalid }"
                     class="btn btn-md btn-primary" ng-click='modify(id)' data-placement="center"><i class="fa fa-fw fa-lg fa-save" bs-tooltip="ttSave"></i>
                     </button>
-                    <button style="margin-left: 100px;" type="button" class="btn btn-md btn-danger"
+                    <button style="margin-left: 100px;" type="button" class="btn btn-md btn-danger" ng-disabled="!isDeleteAllowed"
                     ng-click='remove(id)' data-placement="center"><i class="fa fa-fw fa-lg fa-trash-o" bs-tooltip="ttDelete"></i>
                     </button>
                 </div>

--- a/manage/app/views/pool.html
+++ b/manage/app/views/pool.html
@@ -4,7 +4,7 @@
     <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
             <div class="standard-spacing">
-                <button type="button" ng-click="create()" class="btn btn-md btn-primary pull-right"
+                <button type="button" ng-disabled="!isAddAllowed" ng-click="create()" class="btn btn-md btn-primary pull-right"
                 data-placement="center"><i class="fa fa-lg fa-fw fa-plus-square" bs-tooltip="ttCreate"></i>
 
                 </button>
@@ -26,7 +26,7 @@
                                 <button type="button" ng-click="modify(pool.id)" class="btn btn-md btn-primary"><i class="fa fa-lg fa-fw fa-edit" bs-tooltip="ttEdit"></i>
 
                                 </button>
-                                <button type="button" ng-click="remove(pool)" class="btn btn-md btn-danger"><i class="fa fa-lg fa-fw fa-trash-o" bs-tooltip="ttDelete"></i>
+                                <button type="button" ng-disabled="!isDeleteAllowed" ng-click="remove(pool)" class="btn btn-md btn-danger"><i class="fa fa-lg fa-fw fa-trash-o" bs-tooltip="ttDelete"></i>
 
                                 </button>
                             </td>


### PR DESCRIPTION
1.'Update' button in the 'Cluster Settings' page will be
  disabled.

2.OSD actions 'IN', 'OUT', 'DOWN', 'SCRUB' will be disabled.

3.Pool actions 'New', 'Update' and 'Delete' will be disabled.

This is done by looking at the 'Allow' header of the resources.

Fixes: #10072, #10073, #10074
Signed-off-by: Kanagaraj M <kmayilsa@redhat.com>