### PR TITLE
Fix hostgroup issue in osd-viz during cluster switch

### DIFF
--- a/dashboard/app/scripts/helpers/raphael_support.js
+++ b/dashboard/app/scripts/helpers/raphael_support.js
@@ -70,7 +70,7 @@ define(['underscore', 'raphael'], function() {
             path.push(hdashes(ox, y, xp, step));
             return path.join('');
         };
-    var calculatePosition = function(index, ox, oy, w, h, step, totalNoOsds) {
+    var calculatePosition = function(index, ox, oy, w, h, step, totalNoOsds, cluster) {
             var cols = (w / step) - 1;
             //console.log(cols + ' / ' + rows);
             var startX = ox + step;
@@ -98,9 +98,15 @@ define(['underscore', 'raphael'], function() {
             };
 
         };
+    // OSD positions will change when the cluster is changed
+    // This hash function will force recalculation
+    var calculatePositionHash = function(index, ox, oy, w, h, step, totalNoOsds, cluster) {
+            return cluster + '-' + index;
+        };
     return {
         calcGrid: calcGrid,
-        calcPosition: calculatePosition
+        calcPosition: calculatePosition,
+        calculatePositionHash: calculatePositionHash
     };
 });
 


### PR DESCRIPTION
In Workbench, when OSDs are sorted based on Host, and if the cluster
is switched, then host groups are not shown properly.
This is now fixed by recalculating the positions of OSD if the cluster
is changed

Fixes: #10442
Signed-off-by: Kanagaraj M <kmayilsa@redhat.com>