### PR TITLE
Update package.json files

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -26,7 +26,7 @@
     "connect-livereload": "~0.2.0",
     "grunt-google-cdn": "~0.2.0",
     "grunt-ngmin": "~0.0.2",
-    "yo": "~1.0.0",
+    "yo": "~1.1.0",
     "generator-angular": "0.4.0",
     "grunt-git-describe": "~2.3.2"
   },

--- a/login/package.json
+++ b/login/package.json
@@ -24,7 +24,7 @@
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
-    "yo": "~1.0.0",
+    "yo": "~1.1.0",
     "generator-backbone": "0.1.9",
     "matchdep": "~0.1.1",
     "connect-livereload": "~0.2.0",

--- a/manage/package.json
+++ b/manage/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-contrib-imagemin": "~0.3.0",
+    "grunt-contrib-imagemin": "~0.1.4",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-symlink": "^0.3.0",
     "grunt-contrib-uglify": "~0.2.0",


### PR DESCRIPTION
There are few issues with the package.json files as currently provided in git, these two patches address the problem with missing yo 1.0.0 and too new a version of grunt-contrib-imagemin which caused build failures.