### PR TITLE
substitute cluster-name in disk space graph

### DIFF
--- a/dashboard/app/scripts/templates/graphite/DiskSpaceTargets.ejs
+++ b/dashboard/app/scripts/templates/graphite/DiskSpaceTargets.ejs
@@ -1,1 +1,1 @@
-servers.<%- hostname %>.diskspace._var_lib_ceph_osd_ceph-<%- id %>.<%- metric %>
+servers.<%- hostname %>.diskspace._var_lib_ceph_osd_<%- clusterName %>-<%- id %>.<%- metric %>

--- a/dashboard/app/scripts/views/graphwall-view.js
+++ b/dashboard/app/scripts/views/graphwall-view.js
@@ -598,7 +598,7 @@ define(['jquery', 'underscore', 'backbone', 'templates', 'helpers/graph-utils', 
         // Request the available disk space per OSD ID.
         makeHostDeviceDiskSpaceBytes: function(hostname, id) {
             this.updateBtns(id);
-            return this.makePerHostModelGraphs(hostname, 'makeDiskSpaceBytesGraphUrl', this.getOSDIDs());
+            return this.makePerHostModelGraphs(hostname, 'makeDiskSpaceBytesGraphUrl', this.getOSDIDs(), this.collection.clusterName);
         },
         // **makeHostDeviceDiskSpaceInodes**
         // Request the available inode capacity per OSD ID.


### PR DESCRIPTION
In disk space graph, cluster name was hardcoded to 'ceph'.
So when the cluster name is different the graph is not shown
as the graphite parameters are wrongly generated.

This is now fixied by substituting the cluster name
in the disk-space graph template.

Fixes: #10456
Signed-off-by: Kanagaraj M <kmayilsa@redhat.com>