### PR TITLE
vagrant: parameterize for native build as well as Vagrant build

### DIFF
--- a/vagrant/salt/roots/copyin_build_product.sls
+++ b/vagrant/salt/roots/copyin_build_product.sls
@@ -1,4 +1,6 @@
+{% import 'setvars' as vars with context %}
+
 copyin_build_product:
   cmd.run:
-    - name: cp /git/calamari-clients*tar.gz /home/vagrant/clients
-    - user: vagrant
+    - name: cp {{vars.pkgdest}}/calamari-clients*tar.gz {{vars.builddir}}/{{vars.gitname}}
+    - user: {{vars.username}}

--- a/vagrant/salt/roots/full_build_deps.sls
+++ b/vagrant/salt/roots/full_build_deps.sls
@@ -1,3 +1,4 @@
+{% import 'setvars' as vars with context %}
 full_build_deps:
   pkg.installed:
     - pkgs:
@@ -43,5 +44,5 @@ compass:
 
 fix_mode:
     cmd.run:
-        - name: chown -R vagrant:vagrant /home/vagrant
+        - name: chown -R {{vars.username}}:{{vars.username}} {{vars.home}}
         - user: root

--- a/vagrant/salt/roots/git_clone.sls
+++ b/vagrant/salt/roots/git_clone.sls
@@ -1,7 +1,9 @@
+{% import 'setvars' as vars with context %}
+{% if vars.username == 'vagrant' %}
 git_clone:
   git:
     - latest
     - user: vagrant
     - target: /home/vagrant/clients
     - name: /git/calamari-clients
-
+{% endif %}

--- a/vagrant/salt/roots/make_build_product.sls
+++ b/vagrant/salt/roots/make_build_product.sls
@@ -1,18 +1,18 @@
+{% import 'setvars' as vars with context %}
 make_build_product:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make build-product
     - env:
        - REAL_BUILD: 'y'
-    - cwd: /home/vagrant/clients
+    - cwd: {{vars.builddir}}/{{vars.gitname}}
     - require:
       - cmd: build_calamari_clients
 
 copyout_build_product:
    cmd.run:
-     - user: vagrant
-     - name: cp calamari-clients*tar.gz /git/
-     - cwd: /home/vagrant/clients
+     - user: {{vars.username}}
+     - name: cp calamari-clients*tar.gz {{vars.pkgdest}}
+     - cwd: {{vars.builddir}}/{{vars.gitname}}
      - require:
        - cmd: make_build_product
-

--- a/vagrant/salt/roots/make_deb.sls
+++ b/vagrant/salt/roots/make_deb.sls
@@ -1,18 +1,23 @@
+{% import 'setvars' as vars with context %}
 devscripts:
   pkg.installed
 
 build_calamari_clients:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make dpkg
-    - cwd: /home/vagrant/clients
+    - cwd: {{vars.builddir}}/{{vars.gitname}}
     - require:
+{%- if vars.username == 'vagrant' %}
       - git: git_clone
+{%- endif %}
       - pkg: devscripts
 
+{% if vars.username == 'vagrant' %}
 copy_calamari_clients:
   cmd.run:
-    - name: cp calamari-clients*.deb /git/
-    - cwd: /home/vagrant
+    - name: cp calamari-clients*.deb {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
     - require:
       - cmd: build_calamari_clients
+{% endif %}

--- a/vagrant/salt/roots/make_rpm.sls
+++ b/vagrant/salt/roots/make_rpm.sls
@@ -1,15 +1,18 @@
+{% import 'setvars' as vars with context %}
 build_calamari_clients:
   cmd.run:
     - name: make rpm
-    - user: vagrant
-    - cwd: /home/vagrant/clients
+    - user: {{vars.username}}
+    - cwd: {{vars.builddir}}/{{vars.gitname}}
+{%- if vars.username == 'vagrant' %}
     - require:
       - git: git_clone
+{%- endif %}
 
 copy_calamari_clients:
   cmd.run:
-    - name: cp rpmbuild/RPMS/x86_64/calamari-clients*.rpm /git/
-    - cwd: /home/vagrant
+    - name: cp rpmbuild/RPMS/x86_64/calamari-clients*.rpm {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
     - require:
       - cmd: build_calamari_clients
 

--- a/vagrant/salt/roots/real_make_deb.sls
+++ b/vagrant/salt/roots/real_make_deb.sls
@@ -1,20 +1,25 @@
+{% import 'setvars' as vars with context %}
 devscripts:
   pkg.installed
 
 build_calamari_clients:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make dpkg
     - env:
       - REAL_BUILD: 'y'
-    - cwd: /home/vagrant/clients
+    - cwd: {{vars.builddir}}/{{vars.gitname}}
     - require:
+{%- if vars.username == 'vagrant' %}
       - git: git_clone
+{%- endif %}
       - pkg: devscripts
 
+{% if vars.username == 'vagrant' %}
 copy_calamari_clients:
   cmd.run:
-    - name: cp calamari-clients*.deb /git/
-    - cwd: /home/vagrant
+    - name: cp calamari-clients*.deb {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
     - require:
       - cmd: build_calamari_clients
+{%- endif %}

--- a/vagrant/salt/roots/setvars
+++ b/vagrant/salt/roots/setvars
@@ -1,0 +1,18 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set home = '/home/vagrant' %}
+{%    set gitname = 'clients' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = '/git' %}
+
+{% else %}
+
+{%    set home = salt['user.info'](username)['home'] %}
+{%    set gitname = 'calamari-clients' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', home) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+


### PR DESCRIPTION
Notes on strategy:

git clone is only used for Vagrant builds, hence the {%if's in states that
require it.  git_clone.sls is still present, but gutted for non-vagrant
(we assume Jenkins or the build system has checked out the right branch
to vars.builddir.

gitname exists to allow the Vagrant and non-Vagrant builds to use
different names for the build git repo, since in the case of Vagrant
it's a cloned copy, whereas non-Vagrant builds in the externally-cloned
checked-out version.  The base of the repo is vars.builddir/vars.gitname.

pkgdest is where the output ends up (/git, the shared dir for Vagrant,
or "parent of builddir/gitname", i.e. builddir, for native) and where
the build-output tar is copied in from.